### PR TITLE
v0.1.2

### DIFF
--- a/lib/lab_live/data.ex
+++ b/lib/lab_live/data.ex
@@ -3,11 +3,12 @@ defmodule LabLive.Data do
   Functions to handle data storages.
 
       iex> alias LabLive.Data
-      iex> {:ok, _pid} = Data.start(:a)
+      iex> {:ok, pid} = Data.start(:a)
       iex> 10 |> Data.update(:a)
       :ok
       iex> Data.get(:a)
       10
+      iex> {:reset, ^pid} = Data.start(:a)
 
   Starting multiple properties:
       iex> alias LabLive.Data

--- a/lib/lab_live/execution.ex
+++ b/lib/lab_live/execution.ex
@@ -9,7 +9,7 @@ defmodule LabLive.Execution do
     end
   end
 
-  @spec set(diagram :: Diagram.diagram()) :: :ok
+  @spec set(diagram :: LabLive.Execution.Diagram.diagram()) :: :ok
   def set(diagram) do
     Worker.set_diagram(diagram)
   end

--- a/lib/lab_live/execution.ex
+++ b/lib/lab_live/execution.ex
@@ -29,7 +29,19 @@ defmodule LabLive.Execution do
     end)
   end
 
-  def monitor() do
-    Worker.get_state().frame
+  def monitor(interval \\ 100) do
+    Kino.animate(
+      interval,
+      fn _ ->
+        state = LabLive.Execution.Stash.get()
+        running? = if state.idle?, do: "stopped", else: "running"
+        Kino.Text.new("[#{running?}] #{inspect(state.status)}", terminal: true)
+      end
+    )
+  end
+
+  @spec render(LabLive.Execution.Diagram.diagram()) :: Kino.Markdown.t()
+  def render(diagram) do
+    LabLive.Execution.Diagram.to_mermaid_markdown(diagram) |> Kino.render()
   end
 end

--- a/lib/lab_live/instrument/impl.ex
+++ b/lib/lab_live/instrument/impl.ex
@@ -1,6 +1,7 @@
 defmodule LabLive.Instrument.Impl do
   @callback init(opts :: any()) :: resource :: any()
   @callback read(message :: binary(), resource :: any()) :: {answer :: binary(), info :: any()}
-  @callback after_reply(info :: any(), resource :: any()) :: any()
+  @callback after_reply(info :: any(), resource :: any()) :: :ok
   @callback write(message :: binary(), resource :: any()) :: :ok
+  @callback terminate(reason :: any(), resource :: any()) :: :ok
 end

--- a/lib/lab_live/instrument/impl/demo.ex
+++ b/lib/lab_live/instrument/impl/demo.ex
@@ -21,11 +21,16 @@ defmodule LabLive.Instrument.Impl.Demo do
 
   @impl Impl
   def after_reply(nil, _map) do
-    nil
+    :ok
   end
 
   @impl Impl
   def write(_message, _map) do
+    :ok
+  end
+
+  @impl Impl
+  def terminate(_reason, _map) do
     :ok
   end
 end

--- a/lib/lab_live/instrument/impl/dummy.ex
+++ b/lib/lab_live/instrument/impl/dummy.ex
@@ -21,7 +21,7 @@ defmodule LabLive.Instrument.Impl.Dummy do
 
   @impl Impl
   def after_reply(nil, _map) do
-    nil
+    :ok
   end
 
   @impl Impl
@@ -31,5 +31,10 @@ defmodule LabLive.Instrument.Impl.Dummy do
     else
       :ok
     end
+  end
+
+  @impl Impl
+  def terminate(_reason, _map) do
+    :ok
   end
 end

--- a/lib/lab_live/instrument/impl/pyvisa.ex
+++ b/lib/lab_live/instrument/impl/pyvisa.ex
@@ -6,9 +6,13 @@ defmodule LabLive.Instrument.Impl.Pyvisa do
 
   @impl Impl
   def init(opts) do
+    if not Keyword.has_key?(opts, :address) do
+      raise ":address option is required for #{__MODULE__}."
+    end
+
     python = Keyword.get(opts, :python)
     address = Keyword.get(opts, :address)
-    python_pid = start_python(python)
+    {:ok, python_pid} = start_python(python)
     {python_pid, address}
   end
 
@@ -38,9 +42,12 @@ defmodule LabLive.Instrument.Impl.Pyvisa do
   end
 
   defp start_python(python_exec) do
-    {:ok, pid} =
-      :python.start_link(python_path: @python_src, python: to_charlist(python_exec))
+    case python_exec do
+      nil ->
+        :python.start_link(python_path: @python_src)
 
-    pid
+      python_exec ->
+        :python.start_link(python_path: @python_src, python: to_charlist(python_exec))
+    end
   end
 end

--- a/lib/lab_live/instrument/impl/pyvisa.ex
+++ b/lib/lab_live/instrument/impl/pyvisa.ex
@@ -23,13 +23,18 @@ defmodule LabLive.Instrument.Impl.Pyvisa do
 
   @impl Impl
   def after_reply(nil, _state) do
-    nil
+    :ok
   end
 
   @impl Impl
   def write(message, {python_pid, address}) do
     :python.call(python_pid, :communicate, :write, [address, message])
     :ok
+  end
+
+  @impl Impl
+  def terminate(_reason, {python_pid, _address}) do
+    :python.stop(python_pid)
   end
 
   defp start_python(python_exec) do

--- a/lib/lab_live/instrument/impl/tcp.ex
+++ b/lib/lab_live/instrument/impl/tcp.ex
@@ -30,6 +30,11 @@ defmodule LabLive.Instrument.Impl.Tcp do
     :ok
   end
 
+  @impl Impl
+  def terminate(_reason, _resource) do
+    :ok
+  end
+
   defp connect_and_send(message, address, port) do
     {:ok, socket} = :gen_tcp.connect(address, port, @tcp_opts, 1000)
     :ok = :gen_tcp.send(socket, message)

--- a/lib/lab_live/instrument/port_manager.ex
+++ b/lib/lab_live/instrument/port_manager.ex
@@ -36,7 +36,18 @@ defmodule LabLive.Instrument.PortManager do
   @spec start_instrument(key :: atom(), opts :: opts()) :: DynamicSupervisor.on_start_child()
   def start_instrument(key, opts) do
     name = via_name(key, opts[:model])
-    DynamicSupervisor.start_child(@supervisor, {Port, [{:name, name}, {:key, key} | opts]})
+
+    case DynamicSupervisor.start_child(@supervisor, {Port, [{:name, name}, {:key, key} | opts]}) do
+      {:ok, pid} ->
+        {:ok, pid}
+
+      {:error, {:already_started, pid}} ->
+        Port.reset(pid, opts)
+        {:reset, pid}
+
+      {:error, reason} ->
+        {:error, reason}
+    end
   end
 
   @spec start_instrument(instruments :: map() | Keyword.t()) :: map()

--- a/mix.exs
+++ b/mix.exs
@@ -27,6 +27,7 @@ defmodule LabLive.MixProject do
       {:kino_vega_lite, "~> 0.1.10"},
       {:logger_file_backend, "~> 0.0.13"},
       {:ex_doc, "~> 0.30.8", only: :dev, runtime: false},
+      {:dialyxir, "~> 1.4", only: [:dev, :test], runtime: false},
       {:stream_data, "~> 0.5", only: :test}
     ]
   end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule LabLive.MixProject do
   def project do
     [
       app: :lab_live,
-      version: "0.1.1",
+      version: "0.1.2",
       elixir: "~> 1.15",
       start_permanent: Mix.env() == :prod,
       deps: deps()

--- a/mix.lock
+++ b/mix.lock
@@ -1,8 +1,10 @@
 %{
   "certifi": {:hex, :certifi, "2.12.0", "2d1cca2ec95f59643862af91f001478c9863c2ac9cb6e2f89780bfd8de987329", [:rebar3], [], "hexpm", "ee68d85df22e554040cdb4be100f33873ac6051387baf6a8f6ce82272340ff1c"},
   "combine": {:hex, :combine, "0.10.0", "eff8224eeb56498a2af13011d142c5e7997a80c8f5b97c499f84c841032e429f", [:mix], [], "hexpm", "1b1dbc1790073076580d0d1d64e42eae2366583e7aecd455d1215b0d16f2451b"},
+  "dialyxir": {:hex, :dialyxir, "1.4.2", "764a6e8e7a354f0ba95d58418178d486065ead1f69ad89782817c296d0d746a5", [:mix], [{:erlex, ">= 0.2.6", [hex: :erlex, repo: "hexpm", optional: false]}], "hexpm", "516603d8067b2fd585319e4b13d3674ad4f314a5902ba8130cd97dc902ce6bbd"},
   "earmark_parser": {:hex, :earmark_parser, "1.4.37", "2ad73550e27c8946648b06905a57e4d454e4d7229c2dafa72a0348c99d8be5f7", [:mix], [], "hexpm", "6b19783f2802f039806f375610faa22da130b8edc21209d0bff47918bb48360e"},
   "elixir_uuid": {:hex, :elixir_uuid, "1.2.1", "dce506597acb7e6b0daeaff52ff6a9043f5919a4c3315abb4143f0b00378c097", [:mix], [], "hexpm", "f7eba2ea6c3555cea09706492716b0d87397b88946e6380898c2889d68585752"},
+  "erlex": {:hex, :erlex, "0.2.6", "c7987d15e899c7a2f34f5420d2a2ea0d659682c06ac607572df55a43753aa12e", [:mix], [], "hexpm", "2ed2e25711feb44d52b17d2780eabf998452f6efda104877a3881c2f8c0c0c75"},
   "erlport": {:hex, :erlport, "0.11.0", "8bb46a520e6eb9146e655fbf9b824433d9d532194667069d9aa45696aae9684b", [:rebar3], [], "hexpm", "8eb136ccaf3948d329b8d1c3278ad2e17e2a7319801bc4cc2da6db278204eee4"},
   "ex_doc": {:hex, :ex_doc, "0.30.8", "cf3eb2eb32137966aab0929bb3af42773b2d08e2f785a5fee9caabf664082cb3", [:mix], [{:earmark_parser, "~> 1.4.31", [hex: :earmark_parser, repo: "hexpm", optional: false]}, {:makeup_elixir, "~> 0.14", [hex: :makeup_elixir, repo: "hexpm", optional: false]}, {:makeup_erlang, "~> 0.1", [hex: :makeup_erlang, repo: "hexpm", optional: false]}], "hexpm", "bfb981d8e0a8ab23857e502d611c612ae2c24536dd3b530e741d1d94ea44e6e2"},
   "expo": {:hex, :expo, "0.4.1", "1c61d18a5df197dfda38861673d392e642649a9cef7694d2f97a587b2cfb319b", [:mix], [], "hexpm", "2ff7ba7a798c8c543c12550fa0e2cbc81b95d4974c65855d8d15ba7b37a1ce47"},


### PR DESCRIPTION
- reset servers on `Data.start` and `Instrument.start`

#### Execution
- update stash on every run
- removed kino frame from the worker

#### pyvisa
- use default python when `:python` key is not provided
- assert if `:address` key is provided